### PR TITLE
Fix TravisCI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
     - 3.6
 install:
     - pip install coveralls coverage
-    - pip install -U setuptools==33.1.1
+    - pip install -U setuptools
     - pip install zc.buildout
     - buildout bootstrap
     - buildout


### PR DESCRIPTION
Python 3.5 is currently broken because Zope 4.1 requires a newer setuptools version.