### PR TITLE
Fixed deprecation warning for zope.component.interfaces.IObjectEvent.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Products.CMFUid Changelog
 3.0.3 (unreleased)
 ------------------
 
+- Fixed deprecation warning for zope.component.interfaces.IObjectEvent.
+
 
 3.0.2 (2020-06-24)
 ------------------

--- a/Products/CMFUid/event.zcml
+++ b/Products/CMFUid/event.zcml
@@ -3,7 +3,7 @@
 
   <subscriber
       for="Products.CMFCore.interfaces.IContentish
-           zope.component.interfaces.IObjectEvent"
+           zope.interface.interfaces.IObjectEvent"
       handler=".UniqueIdAnnotationTool.handleUidAnnotationEvent"
       />
 


### PR DESCRIPTION
While loading zcml:

```
DeprecationWarning: IObjectEvent is deprecated.
Import from zope.interface.interfaces
```