### PR TITLE
Drop support for ``python setup.py test``.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Products.CMFUid Changelog
 =========================
 
-3.0.3 (unreleased)
+3.1.0 (unreleased)
 ------------------
 
 - Fixed deprecation warning for zope.component.interfaces.IObjectEvent.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Products.CMFUid Changelog
 
 - Fixed deprecation warning for zope.component.interfaces.IObjectEvent.
 
+- Drop support for ``python setup.py test`` which is broken in Python 3.7+.
+
 
 3.0.2 (2020-06-24)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ README = _boundary.join([
 
 setup(
     name='Products.%s' % NAME,
-    version='3.1.0',
+    version='3.1.0.dev0',
     description='Uid product for the Zope Content Management Framework',
     long_description=README,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ README = _boundary.join([
 
 setup(
     name='Products.%s' % NAME,
-    version='3.0.3.dev0',
+    version='3.1.0',
     description='Uid product for the Zope Content Management Framework',
     long_description=README,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -48,24 +48,19 @@ setup(
     include_package_data=True,
     namespace_packages=['Products'],
     zip_safe=False,
-    setup_requires=[
-        'eggtestinfo',
-    ],
     install_requires=[
         'Products.CMFCore >= 2.4.0dev',
         'Products.ZCatalog >= 4.1.1',
         'Zope',
         'setuptools',
     ],
-    tests_require=[
-        'zope.testing >= 3.7.0',
-    ],
-    test_loader='zope.testing.testrunner.eggsupport:SkipLayers',
-    test_suite='Products.%s.tests' % NAME,
+    extras_require={
+        'test': [
+            'zope.testing >= 3.7.0',
+        ]
+    },
     entry_points="""
     [zope2.initialize]
     Products.%s = Products.%s:initialize
-    [distutils.commands]
-    ftest = zope.testing.testrunner.eggsupport:ftest
     """ % (NAME, NAME),
 )


### PR DESCRIPTION
It is broken in Python 3.7+.