### PR TITLE
Optimization to only reindex cmf_uid after a UID is set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Products.CMFUid Changelog
 3.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- When an object is reindexed after its UID is set,
+  only reindex the ``cmf_uid`` index rather than all indexes.
 
 
 3.3 (2022-07-13)

--- a/src/Products/CMFUid/UniqueIdHandlerTool.py
+++ b/src/Products/CMFUid/UniqueIdHandlerTool.py
@@ -70,8 +70,11 @@ class UniqueIdHandlerTool(UniqueObject, SimpleItem):
     security = ClassSecurityInfo()
 
     def _reindexObject(self, obj):
-        ctool = getToolByName(self, 'portal_catalog')
-        ctool.reindexObject(obj, idxs=[self.UID_ATTRIBUTE_NAME])
+        try:
+            obj.reindexObject(idxs=[self.UID_ATTRIBUTE_NAME])
+        except AttributeError:
+            ctool = getToolByName(self, 'portal_catalog')
+            ctool.reindexObject(obj, idxs=[self.UID_ATTRIBUTE_NAME])
 
     def _setUid(self, obj, uid):
         """Attaches a unique id to the object and does reindexing.
@@ -82,10 +85,7 @@ class UniqueIdHandlerTool(UniqueObject, SimpleItem):
         annotation.setUid(uid)
 
         # reindex the object
-        try:
-            obj.reindexObject()
-        except AttributeError:
-            self._reindexObject(obj)
+        self._reindexObject(obj)
 
     security.declarePublic('register')
 

--- a/src/Products/CMFUid/tests/test_uidhandling.py
+++ b/src/Products/CMFUid/tests/test_uidhandling.py
@@ -291,8 +291,11 @@ class UniqueIdHandlerTests(SecurityTest):
         catalog = self.ctool
         dummy = self.app.dummy
 
-        # mock the portal root, which has empty indexing attributes
-        dummy.reindexObject = lambda: None
+        # An object like the portal root can override
+        # reindexObject to suppress indexing.
+        def reindexObject(idxs=[]):
+            pass
+        dummy.reindexObject = reindexObject
 
         uid = handler.register(dummy)
         brains = catalog(cmf_uid=uid)


### PR DESCRIPTION
In 2008 I [made a change](https://github.com/zopefoundation/Products.CMFUid/commit/1152d486974da8a1ee92092f6b3e4796f6d224ae) to make sure that new UIDs are indexed by calling the reindexObject method on objects that have one. But I didn't specify that only the cmf_uid index should be reindexed, so this can end up doing unnecessary work.

(In practice these days it often doesn't matter thanks to CMF's catalog indexing queue optimization. If the same object is also indexed elsewhere in the same transaction before a query is performed, those operations are collapsed. But there are some cases where a UID is added in a transaction that doesn't include other indexing, or where the indexing queue is processed in between adding a UID and other reindexing. In those cases unnecessary work was performed.)

To fix this I'm now specifying to only reindex the cmf_uid index.

This is a slightly backwards incompatible change in case someone implemented a reindexObject method without an `idxs` keyword argument. I searched the zopefoundation, plone, and collective github organizations and only found one implementation like that, in plone.app.discussion, which I can adjust. ICatalogAware [defines reindexObject with the `idxs` kwarg](https://github.com/zopefoundation/Products.CMFCore/blob/master/src/Products/CMFCore/interfaces/_content.py#L548), so implementations without it do not comply with the interface.

@mauritsvanrees What is the best way to test this change against Plone?